### PR TITLE
correctly handle module that only set package.loaded

### DIFF
--- a/require.lua
+++ b/require.lua
@@ -59,6 +59,8 @@ local function require51 (name)
         module = res
     elseif p_loaded[name] == sentinel or not p_loaded[name] then
         module = true
+    else
+	module = p_loaded[name]
     end
 
     p_loaded[name] = module
@@ -91,6 +93,8 @@ local function require52 (name)
         module = res
     elseif not p_loaded[name] then
         module = true
+    else
+	module = p_loaded[name]
     end
 
     p_loaded[name] = module


### PR DESCRIPTION
running these two scripts yield different results
(these assume you have luasec installed, apt-get install lua-sec under debian)
```lua
print(require("ssl.https"))
```
will print table: 0x25ef070 (or similar)
```lua
require = require("require").require
print(require("ssl.https"))
```
will print nil


This is because ssl.https uses the "module" function and that function sets package.loaded["ssl.https"] which, in turn, means the function doesn't have to return anything.

According to lua documentation (and the way the original require works) this is a legal thing to do and require should return the value of package.loaded["ssl.https"] in that case

